### PR TITLE
demo: update demo to use a class and abstracetd eth api methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.3.0
 - Update from Go API: https://github.com/digitalbitbox/bitbox02-api-go/commit/7817ceb1fccc7276f17a6a468221258cbd4d5bac
     - Includes support for firmware 6.1.0 and makes it the lowest supported version
+- Update sandbox demo to use a class and abstracted ethereum api methods
+- Return arrays instead of Buffers in ethereum signature results and let the caller handle conversion as they require
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ To use with Ethereum, the user needs a BB02 Multi and not the Bitcoin Only editi
 ```javascript
 import { api } from 'bitbox02-api';
 
-BitBox02.fw.Product() === api.common.Product.BitBox02Multi
-BitBox02.fw.Product() === api.common.Product.BitBox02BTCOnly
+BitBox02.firmware().Product() === api.common.Product.BitBox02Multi
+BitBox02.firmware().Product() === api.common.Product.BitBox02BTCOnly
 ```
 
 ## Sample integration
@@ -227,7 +227,7 @@ class BitBox02 {
       return;
     }
 
-    switch (this.BitBox02API.fw.Product()) {
+    switch (this.BitBox02API.firmware().Product()) {
         case api.common.Product.BitBox02Multi:
             console.log("This is a BitBox02 Multi");
             break;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -57,7 +57,7 @@ class BitBox02 {
             reset();
             return;
         }
-        switch (this.BitBox02API.fw.Product()) {
+        switch (this.BitBox02API.firmware().Product()) {
             case api.common.Product.BitBox02Multi:
                 console.log("This is a BitBox02 Multi");
                 break;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,6 +1,8 @@
 import { api, getDevicePath, BitBox02API } from './bitbox02.js'
+import { getCoinFromChainId, getKeypathFromString } from './eth-utils.js'
 
 const firmwareAPI = api.firmware;
+const HARDENED = 0x80000000;
 
 function reset() {
     document.getElementById("demo").disabled = false;
@@ -9,182 +11,191 @@ function reset() {
     document.getElementById("initialized").style.display = "none";
 }
 
-export async function demo() {
-    const pairingOKButton = document.getElementById("pairingOK");
-    const initializedDiv = document.getElementById("initialized");
-    document.getElementById("demo").disabled = true;
+class BitBox02 {
+    constructor(logout) {
+        this.logout = logout;
+        this.status = undefined;
+        this.pairingConfirmed = false;
+    }
 
-    let bitbox02api
-    try {
-        const devicePath = await getDevicePath();
-        bitbox02api = new BitBox02API(devicePath);
-        document.getElementById("close").addEventListener("click", () => {
-          bitbox02api.close();
-          reset();
-        });
-        await bitbox02api.connect(
-            pairingCode => {
-                document.getElementById("pairing").style.display = "block";
-                document.getElementById("pairingCode").innerHTML = pairingCode.replace("\n", "<br/>");
-            },
-            () => {
-                return new Promise(resolve => {
-                    pairingOKButton.disabled = false;
-                    pairingOKButton.addEventListener("click", resolve);
-                });
-            },
-            attestationResult => {
-                alert("Attestation check: " + attestationResult);
-            },
-            () => {
+    async init() {
+        const pairingOKButton = document.getElementById("pairingOK");
+        const initializedDiv = document.getElementById("initialized");
+        document.getElementById("demo").disabled = true;
+        try {
+            const devicePath = await getDevicePath();
+            this.BitBox02API = new BitBox02API(devicePath);
+
+            document.getElementById("close").addEventListener("click", () => {
+                this.BitBox02API.close();
                 reset();
-            },
-            status => {
-                console.log(status);
-            }
-        );
-    } catch(err) {
-        alert(err);
-        reset();
-        return;
-    }
+              });
 
-    const firmware = bitbox02api.firmware();
-
-    // ready to use
-    switch (firmware.Product()) {
-        case api.common.Product.BitBox02Multi:
-            console.log("This is a BitBox02 Multi");
-            break;
-        case api.common.Product.BitBox02BTCOnly:
-            console.log("This is a BitBox02 BTC-only");
-            break;
-    }
-    console.log("supports ETH? ->", firmware.SupportsETH(firmwareAPI.messages.ETHCoin.ETH));
-
+            await this.BitBox02API.connect(
+                pairingCode => {
+                    document.getElementById("pairing").style.display = "block";
+                    document.getElementById("pairingCode").innerHTML = pairingCode.replace("\n", "<br/>");
+                },
+                () => {
+                    return new Promise(resolve => {
+                        pairingOKButton.disabled = false;
+                        pairingOKButton.addEventListener("click", resolve);
+                    });
+                },
+                attestationResult => {
+                    alert("Attestation check: " + attestationResult);
+                },
+                () => {
+                    reset();
+                },
+                status => {
+                    console.log(status);
+                }
+              )
+        } catch (e) {
+            alert(e);
+            reset();
+            return;
+        }
+        switch (this.BitBox02API.fw.Product()) {
+            case api.common.Product.BitBox02Multi:
+                console.log("This is a BitBox02 Multi");
+                break;
+            case api.common.Product.BitBox02BTCOnly:
+                console.log("This is a BitBox02 BTC-only");
+                break;
+        }
 
     document.getElementById("pairing").style.display = "none";
     initializedDiv.style.display = "block";
 
-    // ---- Demo buttons
-
-    const HARDENED = 0x80000000;
-    document.getElementById("btcAddressSimple").addEventListener("click", async () => {
-        const pub = display => firmware.js.AsyncBTCAddressSimple(
-            firmwareAPI.messages.BTCCoin.BTC,
-            [49 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0],
-            firmwareAPI.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH,
-            display,
-        )
-        const addr = await pub(false);
-        pub(true);
-        alert(addr);
-    });
-
-    document.getElementById("btcSignSimple").addEventListener("click", async () => {
-        const bip44Account = 0 + HARDENED;
-        const version = 1;
-        const locktime = 0;
-        const inputs = [
-            {
-                "prevOutHash": new Uint8Array(32).fill(49), // arbitrary constant
-                "prevOutIndex": 1,
-                "prevOutValue": 1e8 * 0.60005,
-                "sequence": 0xFFFFFFFF,
-                "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 0, 0],
-            },
-            {
-                "prevOutHash": new Uint8Array(32).fill(49), // arbitrary constant
-                "prevOutIndex": 1,
-                "prevOutValue": 1e8 * 0.60005,
-                "sequence": 0xFFFFFFFF,
-                "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 0, 1],
-            }
-        ];
-        const outputs = [
-            {
-                "ours": true, // change
-                "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 1, 0],
-                "value": 1e8 * 1,
-            },
-            {
-                "ours": false,
-                "type": firmwareAPI.messages.BTCOutputType.P2WSH,
-                "hash": new Uint8Array(32).fill(49), // arbitrary constant
-                "value": 1e8 * 0.2,
-            },
-        ];
-        try {
-            const signatures = await firmware.js.AsyncBTCSignSimple(
-                firmwareAPI.messages.BTCCoin.BTC,
-                firmwareAPI.messages.BTCScriptConfig_SimpleType.P2WPKH,
-                [84 + HARDENED, 0 + HARDENED, bip44Account],
-                inputs,
-                outputs,
-                version,
-                locktime,
-            );
-            console.log("Signatures: ", signatures);
-        } catch(err) {
-            if (firmwareAPI.IsErrorAbort(err)) {
-                alert("aborted by user");
-            } else {
-                alert(err.Message);
-            }
-        }
-    });
-
-    document.getElementById("ethPub").addEventListener("click", async () => {
-        const pub = display => firmware.js.AsyncETHPub(
-            firmwareAPI.messages.ETHCoin.ETH,
-            [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-            firmwareAPI.messages.ETHPubRequest_OutputType.ADDRESS,
-            display,
-            new Uint8Array(),
-        )
-        const addr = await pub(false);
-        pub(true);
-        alert(addr);
-    });
-
-    ethSign.addEventListener("click", async () => {
-        try {
-            const sig = await firmware.js.AsyncETHSign(
-                firmwareAPI.messages.ETHCoin.ETH,
-                [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                8156,
-                "6000000000",
-                21000,
-                new Uint8Array([4, 242, 100, 207, 52, 68, 3, 19, 180, 160, 25, 42, 53, 40, 20, 251, 233, 39, 184, 133]),
-                "530564000000000000",
-                new Uint8Array([]),
-            );
-            console.log(sig);
-        } catch(err) {
-            if (firmwareAPI.IsErrorAbort(err)) {
-                alert("aborted by user");
-            } else {
-                alert(err.Message);
-            }
-        }
-    });
-
-    ethSignMsg.addEventListener("click", async () => {
-        try {
-            const sig = await firmware.js.AsyncETHSignMessage(
-                firmwareAPI.messages.ETHCoin.ETH,
-                [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, 0],
-                new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
-            );
-            console.log(sig);
-        } catch(err) {
-            if (firmwareAPI.IsErrorAbort(err)) {
-                alert("aborted by user");
-            } else {
-                alert(err.Message);
-            }
-        }
-    });
+  }
 }
 
-document.getElementById("demo").addEventListener("click", demo);
+let device;
+let firmware;
+const runDemo = async () => {
+    device  = new BitBox02(reset)
+    await device.init();
+    // TODO: (@benma) `firmware` is no longer needed after refactoring BTC methods to work like eth with
+    // `device.BitBox02API` and adding them to bitbox02.js
+    firmware = device.BitBox02API.firmware()
+}
+
+// ---- Demo buttons
+
+// Start the demo
+document.getElementById("demo").addEventListener("click", runDemo);
+
+// Get ethereum xpub for given keypath
+ethPub.addEventListener("click", async () => {
+    const ethPub = await device.BitBox02API.ethGetRootPubKey("m/44'/60'/0'/0");
+    alert(ethPub);
+});
+
+// Get ethereum address for given keypath
+// Only displays address on device, does not return. For verification, derive address from xpub
+ethAddr.addEventListener("click", async () => {
+    await device.BitBox02API.ethDisplayAddress("m/44'/60'/0'/0/0");
+});
+
+// Sign ethereum transaction
+ethSign.addEventListener("click", async () => {
+    const tx = {
+        coin: getCoinFromChainId(1), // mainnet tx
+        keypath: getKeypathFromString("m/44'/60'/0'/0/0"), // mainnet tx needs a mainnet keypath
+        nonce: 0,
+        gasPrice: "6000000000",
+        gasLimit: 21000,
+        recipient: new Uint8Array([4, 242, 100, 207, 52, 68, 3, 19, 180, 160, 25, 42, 53, 40, 20, 251, 233, 39, 184, 133]),
+        value: "530564000000000000",
+        data: new Uint8Array([])
+    }
+    try {
+        const sig = await device.BitBox02API.ethSignTransaction(tx);
+        console.log(sig);
+    } catch(e) {
+        alert(e);
+    }
+});
+
+// Sign "hello world" ethereum message
+ethSignMsg.addEventListener("click", async () => {
+    try {
+        const sig = await device.BitBox02API.ethSignMessage({
+                keypath: "m/44'/60'/0'/0/0",
+                // "hello world"
+                message: new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+            }
+        );
+        console.log(sig);
+    } catch(e) {
+        alert(e)
+    }
+});
+
+// TODO: (@benma) refactor to use `device.BitBox02API` instead
+document.getElementById("btcAddressSimple").addEventListener("click", async () => {
+    const pub = display => firmware.js.AsyncBTCAddressSimple(
+        firmwareAPI.messages.BTCCoin.BTC,
+        [49 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0],
+        firmwareAPI.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH,
+        display,
+    )
+    const addr = await pub(false);
+    pub(true);
+    alert(addr);
+});
+
+document.getElementById("btcSignSimple").addEventListener("click", async () => {
+    const bip44Account = 0 + HARDENED;
+    const version = 1;
+    const locktime = 0;
+    const inputs = [
+        {
+            "prevOutHash": new Uint8Array(32).fill(49), // arbitrary constant
+            "prevOutIndex": 1,
+            "prevOutValue": 1e8 * 0.60005,
+            "sequence": 0xFFFFFFFF,
+            "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 0, 0],
+        },
+        {
+            "prevOutHash": new Uint8Array(32).fill(49), // arbitrary constant
+            "prevOutIndex": 1,
+            "prevOutValue": 1e8 * 0.60005,
+            "sequence": 0xFFFFFFFF,
+            "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 0, 1],
+        }
+    ];
+    const outputs = [
+        {
+            "ours": true, // change
+            "keypath": [84 + HARDENED, 0 + HARDENED, bip44Account, 1, 0],
+            "value": 1e8 * 1,
+        },
+        {
+            "ours": false,
+            "type": firmwareAPI.messages.BTCOutputType.P2WSH,
+            "hash": new Uint8Array(32).fill(49), // arbitrary constant
+            "value": 1e8 * 0.2,
+        },
+    ];
+    try {
+        const signatures = await firmware.js.AsyncBTCSignSimple(
+            firmwareAPI.messages.BTCCoin.BTC,
+            firmwareAPI.messages.BTCScriptConfig_SimpleType.P2WPKH,
+            [84 + HARDENED, 0 + HARDENED, bip44Account],
+            inputs,
+            outputs,
+            version,
+            locktime,
+        );
+        console.log("Signatures: ", signatures);
+    } catch(err) {
+        if (firmwareAPI.IsErrorAbort(err)) {
+            alert("aborted by user");
+        } else {
+            alert(err.Message);
+        }
+    }
+});

--- a/demo/eth-utils.js
+++ b/demo/eth-utils.js
@@ -1,0 +1,1 @@
+../src/eth-utils.js

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,7 +24,8 @@
             <button id="btcSignSimple" autocomplete="off">BTC Sign (single-sig)</button>
             <br/>
             <strong>ETH</strong>
-            <button id="ethPub" autocomplete="off">ETH address</button>
+            <button id="ethAddr" autocomplete="off">ETH address</button>
+            <button id="ethPub" autocomplete="off">ETH xpub</button>
             <button id="ethSign" autocomplete="off">ETH sign</button>
             <button id="ethSignMsg" autocomplete="off">ETH sign message</button>
             <button id="close" autocomplete="off">Close</button>

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -1,6 +1,6 @@
 import './bitbox02-api-go.js';
 
-import { getKeypathFromString, getCoinFromKeypath } from './eth-utils';
+import { getKeypathFromString, getCoinFromKeypath } from './eth-utils.js';
 
 export const api = bitbox02;
 export const firmwareAPI = api.firmware;
@@ -188,9 +188,9 @@ export class BitBox02API {
             const chainId = sigData.chainId;
             const vOffset = chainId * 2 + 8;
             const result = {
-                r: new Buffer(sig.slice(0, 0 + 32)),
-                s: new Buffer(sig.slice(0 + 32, 0 + 32 + 32)),
-                v: new Buffer([parseInt(sig.slice(64), 16) + 27 + vOffset])
+                r: sig.slice(0, 0 + 32),
+                s: sig.slice(0 + 32, 0 + 32 + 32),
+                v: [parseInt(sig.slice(64), 16) + 27 + vOffset]
             };
             return result;
         } catch (err) {
@@ -204,16 +204,17 @@ export class BitBox02API {
 
     async ethSignMessage(msgData) {
         try {
+          const keypath = getKeypathFromString(msgData.keypath);
           const sig = await this.fw.js.AsyncETHSignMessage(
-            firmwareAPI.messages.ETHCoin.ETH,
-            [44 + HARDENED, 60 + HARDENED, 0 + HARDENED, 0, msgData.account],
+            getCoinFromKeypath(keypath),
+            keypath,
             msgData.message
           );
 
           const result = {
-              r: new Buffer(sig.slice(0, 0 + 32)),
-              s: new Buffer(sig.slice(0 + 32, 0 + 32 + 32)),
-              v: new Buffer([parseInt(sig.slice(64), 16) + 27])
+              r: sig.slice(0, 0 + 32),
+              s: sig.slice(0 + 32, 0 + 32 + 32),
+              v: [parseInt(sig.slice(64), 16) + 27]
           };
           return result;
         } catch(err) {

--- a/src/eth-utils.js
+++ b/src/eth-utils.js
@@ -1,6 +1,6 @@
-import { firmwareAPI, HARDENED } from './bitbox02';
+import { firmwareAPI, HARDENED } from './bitbox02.js';
 
-const getCoinFromChainId = chainId => {
+export const getCoinFromChainId = chainId => {
     switch(chainId) {
         case 1:
             return firmwareAPI.messages.ETHCoin.ETH;


### PR DESCRIPTION
- update demo to use a class and abstracetd eth api methods
- Change eth methods to return arrays instead of Buffers and let the
  caller handle that instead as necessary