### PR TITLE
cors: handle http response returned by the bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - add btcXPub, btcMaybeRegisterScriptConfig, btcDisplayAddressMultisig, btcSignMultisig api calls.
 - bitobx02-api-go: updated to 49d314b148cccb193e26b5c154044ed7eb819384 (v7.0.0 compatibility)
 - Add Jest framework and Travis CI for testing and add unit tests for util functions
+- Improve error handling with regards to CORS headers when connecting to the device. We can now correctly identify when the origin is not whitelisted based on the response from the bridge
 
 # 0.3.0
 - Update from Go API: https://github.com/digitalbitbox/bitbox02-api-go/commit/7817ceb1fccc7276f17a6a468221258cbd4d5bac

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -16,13 +16,21 @@ export async function getDevicePath() {
     const attempts = 10;
     for (let i=0; i<attempts; i++){
         let response;
+        let errorMessage;
         try {
             response = await fetch("http://localhost:8178/api/v1/devices", {
                 method: 'GET',
                 headers: {},
-            });
+            })
+            if (!response.ok && response.status === 403) {
+                errorMessage = 'Origin not whitelisted';
+                throw new Error();        
+            } else if (!response.ok) {
+                errorMessage = 'Unexpected';
+                throw new Error();
+            }
         } catch {
-            throw new Error('BitBoxBridge not found');
+            throw new Error(errorMessage ? errorMessage : 'BitBoxBridge not found');
         }
         const devices = (await response.json()).devices;
         if (devices.length !== 1) {


### PR DESCRIPTION
With the improvements in
https://github.com/digitalbitbox/bitbox-bridge/pull/4/files we can now
correctly distinguish what kind of response the bridge returns and
invoke the appropriate error, sich as "Origin not whitelisted" when
the brdige returns 403