### PR TITLE
docs: move method docs to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,44 +3,58 @@
 The JavaScript library is compiled from
 [bitbox02-api-go](https://github.com/digitalbitbox/bitbox02-api-go) using GopherJS.
 
-Given that it contains the full client implentation compiled from Go, the library is quite large (~3MB), we recommend lazy-loading it only when necessary.
+Given that it contains the full client implentation compiled from Go, the library is quite large (~3MB).
+We recommend lazy-loading it only when necessary.
 
-## Develop locally
+## Local development
 
-To compile:
+To compile the library using GopherJS, run the following commands to run the provided [Dockerfile](Dockerfile).
 
 ```sh
 $ make dockerinit
 $ make dockercompile
 ```
 
-To run a demo: `$ make servedemo` and visit `localhost:8000`
+To simply run the demo sandbox implementation, run the following command and visit <http://localhost:8000>.
+
+```sh
+$ make servedemo
+```
 
 ## Integration
 
-To talk to the device from a browser using this API, you will need the BitBoxBridge: https://github.com/digitalbitbox/bitbox-bridge
-To integrate the BitBox02 into your application, your domain will need to be whitelisted in the Bridge. To do so, please submit a Pull Request or an Issue in the [bitbox-bridge](https://github.com/digitalbitbox/bitbox-bridge) repo.
+To enable communication from the local browser to the BitBox02, the user needs to have the [BitBoxBridge](https://github.com/digitalbitbox/bitbox-bridge) installed.
 
-### Install:
+When integrating the BitBox02 into your application, your domain needs to be whitelisted in the BitBoxBridge.
+To do so, please submit a Pull Request or an Issue in the [bitbox-bridge](https://github.com/digitalbitbox/bitbox-bridge) repository.
+
+The BitBox02 Javascript library is available as NPM package [bitbox02-api](https://www.npmjs.com/package/bitbox02-api).
+
+### Install
+
 ```sh
 $ npm install bitbox02-api
 ```
 
 ### Import
+
 ```javascript
 import { BitBox02API, getDevicePath} from 'bitbox02-api';
 ```
 
 ### Initialize
-To get the device path, the BitBoxBridge needs to be running
+
+To get the device path, the BitBoxBridge needs to be running.
 
 ```javascript
 const devicePath = await getDevicePath();
 const BitBox02 = new BitBox02API(devicePath);
 ```
 
-### Connect
+### Connect to device
+
 The `BitBox02API.connect()` method takes 5 arguments:
+
 ```javascript
 /**
  * @param showPairingCb Callback that is used to show pairing code. Must not block.
@@ -53,78 +67,11 @@ The `BitBox02API.connect()` method takes 5 arguments:
 connect (showPairingCb, userVerify, handleAttestationCb, onCloseCb, setStatusCb)
 ```
 
-For more detailed example see the [Sample integration](https://github.com/digitalbitbox/bitbox02-api-js/blob/master/README.md#sample-integration) below.
+### Check BitBox02 edition
 
-### Methods and functions
+The BitBox02 is available in two editions: "Multi" and "Bitcoin-only".
+To check what edition is used, e.g. to make sure that Ethereum functionality is supported, use the following function.
 
-#### ethGetRootPubKey: Get Ethereum Root Pub Key
-Get eth xpub for a given coin and derivation path
-
-```javascript
-/**
- * @param keypath account keypath in string format
- * Currently only two keypaths are supported:
- * - `m/44'/60'/0'/0` for mainnet and
- * - `m/44'/1'/0'/0`  for Rinkeby and Ropsten testnets
- * @returns string; ethereum extended public key
- */
-const rootPub = await BitBox02.ethGetRootPubKey(keypath: string);
-```
-
-#### ethSignTransaction: Sign Ethereum transaction
-To sign Ethereum transactions, we recommend using the `Transaction` type provided by the `ethereumjs` library https://github.com/ethereumjs/ethereumjs-tx/blob/master/src/transaction.ts.
-
-Then to send the data to the device and get the signature bytes:
-```javascript
-
-/**
- * Signs an ethereum transaction on device
- * @param signingData Object;
- * signingData = {
- *     keypath, // string, e.g. m/44'/60'/0'/0/0
- *     chainId, // number, currently 1, 3 or 4 for Mainnet, Ropsten and Rinkeby respectively
- *     tx       // Object, either as provided by the `Transaction` type from `ethereumjs` library
- *              // or including `nonce`, `gasPrice`, `gasLimit`, `to`, `value`, and `data` as byte arrays
- * }
- * @returns Object; result with the signature bytes r, s, v
- * result = {
- *     r: Uint8Array(32)
- *     s: Uint8Array(32)
- *     v: Uint8Array(1)
- * }
- */
-const result = await BitBox02.ethSignTransaction(signingData);
-```
-
-#### ethSignMessage: Sign Ethereum messages
-```javascript
-/** @param msgData is an object including the keypath and the message as bytes/Buffer:
-  *
-  * const msgData = {
-  *     keypath    // string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
-  *     message    // Buffer/Uint8Array
-  *   }
-  *
-  * @returns Object; result with the signature bytes r, s, v
-  * result = {
-  *   r: Uint8Array(32)
-  *   s: Uint8Array(32)
-  *   v: Uint8Array(1)
-  * }
-  */
-const result = await BitBox02.ethSignMessage(msgData);
-```
-
-#### ethDisplayAddress: Display Ethereum address on BitBox02 screen for verification
-```javascript
-/**
- * @param keypath string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
- */
-await BitBox02.ethDisplayAddress(keypath)
-```
-
-#### Check if product is supported
-To use with Ethereum, the user needs a BB02 Multi and not the Bitcoin Only edition. You can use for the following check:
 ```javascript
 import { constants } from 'bitbox02-api';
 
@@ -132,9 +79,14 @@ BitBox02.firmware().Product() === constants.Product.BitBox02Multi
 BitBox02.firmware().Product() === constants.Product.BitBox02BTCOnly
 ```
 
+### Methods
+
+All available methods are documented in [`docs/methods.md`](docs/methods.md).
+
 ## Sample integration
+
 This is a sample BitBox02Wallet class integration for connecting to the BitBox02 device using the BitBoxBridge and this JS API.
-For a functioning sandbox implementation, you can see `demo.js`: https://github.com/digitalbitbox/bitbox02-api-js/blob/master/demo/demo.js
+See [`demo/demo.js`](demo/demo.js) for a fully functional sandbox implementation.
 
 ```javascript
 import {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We recommend lazy-loading it only when necessary.
 
 ## Local development
 
-To compile the library using GopherJS, run the following commands to run the provided [Dockerfile](Dockerfile).
+To compile the library using GopherJS, run the following commands:
 
 ```sh
 $ make dockerinit
@@ -23,10 +23,11 @@ $ make servedemo
 
 ## Integration
 
-To enable communication from the local browser to the BitBox02, the user needs to have the [BitBoxBridge](https://github.com/digitalbitbox/bitbox-bridge) installed.
+To enable communication from the browser to the BitBox02, the [BitBoxBridge](https://github.com/digitalbitbox/bitbox-bridge) needs to be installed and running.
 
 When integrating the BitBox02 into your application, your domain needs to be whitelisted in the BitBoxBridge.
 To do so, please submit a Pull Request or an Issue in the [bitbox-bridge](https://github.com/digitalbitbox/bitbox-bridge) repository.
+Localhost is already whitelisted, so you can develop locally.
 
 The BitBox02 Javascript library is available as NPM package [bitbox02-api](https://www.npmjs.com/package/bitbox02-api).
 

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,0 +1,208 @@
+# Methods
+
+The [BitBox02 JavaScript library](https://github.com/digitalbitbox/bitbox02-api-js) supports the methods documented below.
+
+For a fully functional sandbox implementation see [`demo/demo.js`](https://github.com/digitalbitbox/bitbox02-api-js/blob/master/demo/demo.js).
+
+## Bitcoin
+
+The following methods implement Bitcoin functionality.
+
+### btcXPub
+
+Get a Bitcoin xPub key for a given coin and derivation path.
+
+```javascript
+/**
+ * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
+ * @param keypath account-level keypath, for example `getKeypathFromString("m/49'/0'/0'")`.
+ * @param xpubType xpub version - `constants.messages.BTCXPubType.*`, for example `constants.messages.BTCXPubType.YPUB`.
+ * @param display if true, the device device will show the xpub on the screen before returning.
+ * @return the xpub string.
+ */
+const xPub = await BitBox02.btcXPub(coin, keypath, xpubType, display);
+```
+
+### btcDisplayAddressSimple
+
+Display a Bitcoin single-sig address on the device.
+The address to be shown in the wallet is usually derived from the xpub (see `btcXPub`) and account type.
+
+```javascript
+/**
+ * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
+ * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
+ *                Note: the keypaths are strictly enforced according to bip44, and must match the provided script/address types.
+ * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
+ */
+await BitBox02.btcDisplayAddressSimple(coin, keypath, simpleType);
+```
+
+### btcSignSimple
+
+Sign a Bitcoin single-sig transaction.
+
+```javascript
+/**
+ * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
+ * @param simpleType same as in `btcDisplayAddresssimple`.
+ * @param keypathAccount account-level keypath, for example `getKeypathFromString("m/84'/0'/0'")`.
+ *                       All inputs and changes must be from this account.
+ * @param inputs array of input objects, with each input:
+ *               {
+ *                 "prevOutHash": Uint8Array(32),
+ *                 "prevOutIndex": number,
+ *                 "prevOutValue": string, // satoshis as a decimal string,
+ *                 "sequence": number, // usually 0xFFFFFFFF
+ *                 "keypath": [number], // usually keypathAccount.concat([change, address]),
+ *               }
+ * @param outputs array of output objects, with each output being either regular output or a change output:
+ *                Change outputs:
+ *                {
+ *                  "ours": true,
+ *                  "keypath": [number], // usually keypathAccount.concat([1, <address>]),
+ *                  "value": string, // satoshis as a decimal string,
+ *                }
+ *                Regular outputs:
+ *                {
+ *                  "ours": false,
+ *                  "type": constants.messages.BTCOutputType.P2WSH // e.g. constants.messages.BTCOutputType.P2PKH,
+ *                  // pubkey or script hash. 20 bytes for P2PKH, P2SH, P2WPKH. 32 bytes for P2WSH.
+ *                  "hash": new Uint8Array(20) | new Uint8Array(32)
+ *                  "value": string, // satoshis as a decimal string,
+ *                }
+ * @param version Transaction version, usually 1 or 2.
+ * @param locktime Transaction locktime, usually 0.
+ * @return Array of 64 byte signatures, one per input.
+ */
+const signatures = await btcSignSimple(coin, simpleType, keypathAccount, inputs, outputs, version, locktime);
+```
+
+### btcMaybeRegisterScriptConfig
+
+Register a Bitcoin multisig account on the device with a user chosen name.
+If it is already registered, this does nothing.
+A multisig account must be registered before it can be used to show multisig addresses or sign multisig transactions.k
+
+Note: Currently, only P2WSH (bech32) multisig accounts on the keypath `m/48'/<coin>'/<account>'/2'` are supported.
+
+```javascript
+/**
+ * @param account account object details:
+ * {
+ *   "coin": constants.messages.BTCCoin, // for example constants.messages.BTCCoin.BTC
+ *   "keypathAccount": [number], // account-level keypath, for example `getKeypathFromString("m/48'/0'/0'/2'")`.
+ *   "threshold": number, // signing threshold, e.g. 2.
+ *   "xpubs": [string], // list of account-level xpubs given in any format. One of them must belong to the connected BitBox02.
+ *   "ourXPubIndex": nmber, // index of the currently connected BitBox02's multisig xpub in the xpubs array, e.g. 0.
+ * }
+ * @param getName: async () => string - If the account is unknown to the device, this function will be called to get an
+ *                 account name from the user. The resulting name must be between 1 and 30 ascii chars.
+ */
+await btcMaybeRegisterScriptConfig(account, getName);
+```
+
+### btcDisplayAddressMultisig
+
+Display a Bitcoin multisig address on the device.
+`btcMaybeRegisterScriptConfig` should be called beforehand.
+
+```javascript
+/*
+ * @param account same as in `btcMaybeRegisterScriptConfig`.
+ * @param keypath address-level keypath from the account, usually `account.keypathAccount.concat([0, address])`.
+ */
+await btcDisplayAddressMultisig(account, keypath);
+```
+
+### btcSignMultisig
+
+Sign a Bitcoin multisig transaction.
+`btcMaybeRegisterScriptConfig` should be called beforehand.
+
+```javascript
+/*
+ * @param account same as in `btcMaybeRegisterScriptConfig`.
+ * Other params and return are the same as in `btcSignSimple`.
+ */
+await btcSignMultisig(account, inputs, outputs, version, locktime);
+```
+
+## Ethereum
+
+The following methods implement Ethereum functionality.
+These are only supported by the "BitBox02 Multi edition".
+
+### ethGetRootPubKey
+
+Get Ethereum xPub key for a given coin and derivation path.
+
+```javascript
+/**
+ * @param keypath account keypath in string format
+ * Currently only two keypaths are supported:
+ * - `m/44'/60'/0'/0` for mainnet and
+ * - `m/44'/1'/0'/0`  for Rinkeby and Ropsten testnets
+ * @returns string; ethereum extended public key
+ */
+const rootPub = await BitBox02.ethGetRootPubKey(keypath: string);
+```
+
+### ethDisplayAddress
+
+Display an Ethereum address on the device screen for verification.
+
+```javascript
+/**
+ * @param keypath string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
+ */
+await BitBox02.ethDisplayAddress(keypath);
+```
+
+### ethSignTransaction
+
+Signs an Ethereum transaction on the device.
+
+To sign Ethereum transactions, we recommend using the [`Transaction` type](https://github.com/ethereumjs/ethereumjs-tx/blob/master/src/transaction.ts) provided by the `ethereumjs` library.
+Then use this method to send the data to the device and get the signature bytes.
+
+```javascript
+/**
+ * @param signingData Object;
+ * signingData = {
+ *     keypath, // string, e.g. m/44'/60'/0'/0/0
+ *     chainId, // number, currently 1, 3 or 4 for Mainnet, Ropsten and Rinkeby respectively
+ *     tx       // Object, either as provided by the `Transaction` type from `ethereumjs` library
+ *              // or including `nonce`, `gasPrice`, `gasLimit`, `to`, `value`, and `data` as byte arrays
+ * }
+ * @returns Object; result with the signature bytes r, s, v
+ * result = {
+ *     r: Uint8Array(32)
+ *     s: Uint8Array(32)
+ *     v: Uint8Array(1)
+ * }
+ */
+const result = await BitBox02.ethSignTransaction(signingData);
+```
+
+### ethSignMessage
+
+Sign an Ethereum message on the device.
+
+```javascript
+/** @param msgData is an object including the keypath and the message as bytes/Buffer:
+  *
+  * const msgData = {
+  *     keypath    // string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
+  *     message    // Buffer/Uint8Array
+  *   }
+  *
+  * @returns Object; result with the signature bytes r, s, v
+  * result = {
+  *   r: Uint8Array(32)
+  *   s: Uint8Array(32)
+  *   v: Uint8Array(1)
+  * }
+  */
+const result = await BitBox02.ethSignMessage(msgData);
+```

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -24,7 +24,7 @@ export async function getDevicePath() {
             })
             if (!response.ok && response.status === 403) {
                 errorMessage = 'Origin not whitelisted';
-                throw new Error();        
+                throw new Error();
             } else if (!response.ok) {
                 errorMessage = 'Unexpected';
                 throw new Error();
@@ -167,6 +167,7 @@ export class BitBox02API {
     }
 
     /**
+     * btcXPub: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcxpub
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param keypath account-level keypath, for example `getKeypathFromString("m/49'/0'/0'")`.
      * @param xpubType xpub version - `constants.messages.BTCXPubType.*`, for example `constants.messages.BTCXPubType.YPUB`.
@@ -178,10 +179,9 @@ export class BitBox02API {
     }
 
     /**
-     * Display a single-sig address on the device. The address to be shown in the wallet is usually derived from the xpub (see `btcXPub` and account type.
+     * btcDisplayAddressSimple: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcdisplayaddresssimple
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
-     *                Note: the keypaths are strictly enforced according to bip44, and must match the provided script/address types.
      * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
      */
     async btcDisplayAddressSimple(coin, keypath, simpleType) {
@@ -195,34 +195,12 @@ export class BitBox02API {
     }
 
     /**
-     * Sign a single-sig transaction.
+     * btcSignSimple: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcsignsimple
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param simpleType same as in `btcDisplayAddresssimple`.
      * @param keypathAccount account-level keypath, for example `getKeypathFromString("m/84'/0'/0'")`.
-     *                       All inputs and changes must be from this account.
-     * @param inputs array of input objects, with each input:
-     *               {
-     *                 "prevOutHash": Uint8Array(32),
-     *                 "prevOutIndex": number,
-     *                 "prevOutValue": string, // satoshis as a decimal string,
-     *                 "sequence": number, // usually 0xFFFFFFFF
-     *                 "keypath": [number], // usually keypathAccount.concat([change, address]),
-     *               }
-     * @param outputs array of output objects, with each output being either regular output or a change output:
-     *                Change outputs:
-     *                {
-     *                  "ours": true,
-     *                  "keypath": [number], // usually keypathAccount.concat([1, <address>]),
-     *                  "value": string, // satoshis as a decimal string,
-     *                }
-     *                Regular outputs:
-     *                {
-     *                  "ours": false,
-     *                  "type": constants.messages.BTCOutputType.P2WSH // e.g. constants.messages.BTCOutputType.P2PKH,
-     *                  // pubkey or script hash. 20 bytes for P2PKH, P2SH, P2WPKH. 32 bytes for P2WSH.
-     *                  "hash": new Uint8Array(20) | new Uint8Array(32)
-     *                  "value": string, // satoshis as a decimal string,
-     *                }
+     * @param inputs array of input objects
+     * @param outputs array of output objects, with each output being either regular output or a change output
      * @param version Transaction version, usually 1 or 2.
      * @param locktime Transaction locktime, usually 0.
      * @return Array of 64 byte signatures, one per input.
@@ -248,18 +226,8 @@ export class BitBox02API {
     }
 
     /**
-     * Register a multisig account on the device with a user chosen name. If it is already registered, this does nothing.
-     * A multisig account must be registered before it can be used to show multisig addresses or sign multisig transactions.
-     * Note:
-     * Currently, only P2WSH (bech32) multisig accounts on the keypath `m/48'/<coin>'/<account>'/2'` are supported.
-     * @param account account object details:
-     * {
-     *   "coin": constants.messages.BTCCoin, // for example constants.messages.BTCCoin.BTC
-     *   "keypathAccount": [number], // account-level keypath, for example `getKeypathFromString("m/48'/0'/0'/2'")`.
-     *   "threshold": number, // signing threshold, e.g. 2.
-     *   "xpubs": [string], // list of account-level xpubs given in any format. One of them must belong to the connected BitBox02.
-     *   "ourXPubIndex": nmber, // index of the currently connected BitBox02's multisig xpub in the xpubs array, e.g. 0.
-     * }
+     * btcMaybeRegisterScriptConfig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcmayberegisterscriptconfig
+     * @param account account object details
      * @param getName: async () => string - If the account is unknown to the device, this function will be called to get an
      *                 account name from the user. The resulting name must be between 1 and 30 ascii chars.
      */
@@ -271,7 +239,7 @@ export class BitBox02API {
     }
 
     /*
-     * Display a multisig address on the device. `btcMaybeRegisterScriptConfig` should be called beforehand.
+     * btcDisplayAddressMultisig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcdisplayaddressmultisig
      * @param account same as in `btcMaybeRegisterScriptConfig`.
      * @param keypath address-level keypath from the account, usually `account.keypathAccount.concat([0, address])`.
      */
@@ -285,7 +253,7 @@ export class BitBox02API {
     }
 
     /*
-     * Sign a multisig transaction. `btcMaybeRegisterScriptConfig` should be called beforehand.
+     * btcSignMultisig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcsignmultisig
      * @param account same as in `btcMaybeRegisterScriptConfig`.
      * Other params and return are the same as in `btcSignSimple`.
      */
@@ -306,10 +274,8 @@ export class BitBox02API {
     }
 
     /**
+     * ethGetRootPubKey: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethgetrootpubkey
      * @param keypath account keypath in string format
-     * Currently only two keypaths are supported:
-     * - `m/44'/60'/0'/0` for mainnet and
-     * - `m/44'/1'/0'/0`  for Rinkeby and Ropsten testnets
      * @returns string; ethereum extended public key
      */
     async ethGetRootPubKey(keypath) {
@@ -326,9 +292,8 @@ export class BitBox02API {
     };
 
     /**
+     * ethDisplayAddress: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethdisplayaddress
      * @param keypath string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
-     * Displays the address of the provided ethereum account on device screen
-     * Only displays address on device, does not return. For verification, derive address from xpub
      */
     async ethDisplayAddress(keypath) {
         const keypathArray = getKeypathFromString(keypath);
@@ -345,20 +310,9 @@ export class BitBox02API {
     };
 
     /**
-     * Signs an ethereum transaction on device
-     * @param signingData Object;
-     * signingData = {
-     *     keypath, // string, e.g. m/44'/60'/0'/0/0
-     *     chainId, // number, currently 1, 3 or 4 for Mainnet, Ropsten and Rinkeby respectively
-     *     tx       // Object, either as provided by the `Transaction` type from `ethereumjs` library
-     *              // or including `nonce`, `gasPrice`, `gasLimit`, `to`, `value`, and `data` as byte arrays
-     * }
+     * ethSignTransaction: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethsigntransaction
+     * @param signingData Object
      * @returns Object; result with the signature bytes r, s, v
-     * result = {
-     *     r: Uint8Array(32)
-     *     s: Uint8Array(32)
-     *     v: Uint8Array(1)
-     * }
      */
     async ethSignTransaction(signingData) {
         try {
@@ -388,19 +342,10 @@ export class BitBox02API {
         }
     };
 
-    /** @param msgData is an object including the keypath and the message as bytes:
-     *
-     * const msgData = {
-     *     keypath    // string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
-     *     message    // Buffer/Uint8Array
-     * }
-     *
+    /**
+     * ethSignMessage: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethsignmessage
+     * @param msgData is an object including the keypath and the message as bytes
      * @returns Object; result with the signature bytes r, s, v
-     * result = {
-     *     r: Uint8Array(32)
-     *     s: Uint8Array(32)
-     *     v: Uint8Array(1)
-     * }
      */
     async ethSignMessage(msgData) {
         try {

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -1,3 +1,19 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// For full method documentation see: https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md
+
 import './bitbox02-api-go.js';
 
 import { getKeypathFromString, getCoinFromKeypath, getCoinFromChainId } from './utils.js';
@@ -166,8 +182,12 @@ export class BitBox02API {
         });
     }
 
+
+    // --- Bitcoin methods ---
+
     /**
-     * btcXPub: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcxpub
+     * # Get a Bitcoin xPub key for a given coin and derivation path.
+     *
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param keypath account-level keypath, for example `getKeypathFromString("m/49'/0'/0'")`.
      * @param xpubType xpub version - `constants.messages.BTCXPubType.*`, for example `constants.messages.BTCXPubType.YPUB`.
@@ -179,7 +199,9 @@ export class BitBox02API {
     }
 
     /**
-     * btcDisplayAddressSimple: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcdisplayaddresssimple
+     * # Display a single-sig address on the device. The address to be shown in the wallet is usually derived 
+     * # from the xpub (see `btcXPub` and account type.
+     *
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
      * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
@@ -195,7 +217,8 @@ export class BitBox02API {
     }
 
     /**
-     * btcSignSimple: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcsignsimple
+     * # Sign a Bitcoin single-sig transaction.
+     *
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param simpleType same as in `btcDisplayAddresssimple`.
      * @param keypathAccount account-level keypath, for example `getKeypathFromString("m/84'/0'/0'")`.
@@ -226,8 +249,19 @@ export class BitBox02API {
     }
 
     /**
-     * btcMaybeRegisterScriptConfig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcmayberegisterscriptconfig
-     * @param account account object details
+     * # Register a multisig account on the device with a user chosen name. If it is already registered, this does nothing.
+     * # A multisig account must be registered before it can be used to show multisig addresses or sign multisig transactions.
+     * # Note:
+     * # Currently, only P2WSH (bech32) multisig accounts on the keypath `m/48'/<coin>'/<account>'/2'` are supported.
+     *
+     * @param account account object details:
+     * {
+     *   "coin": constants.messages.BTCCoin, // for example constants.messages.BTCCoin.BTC
+     *   "keypathAccount": [number], // account-level keypath, for example `getKeypathFromString("m/48'/0'/0'/2'")`.
+     *   "threshold": number, // signing threshold, e.g. 2.
+     *   "xpubs": [string], // list of account-level xpubs given in any format. One of them must belong to the connected BitBox02.
+     *   "ourXPubIndex": nmber, // index of the currently connected BitBox02's multisig xpub in the xpubs array, e.g. 0.
+     * }
      * @param getName: async () => string - If the account is unknown to the device, this function will be called to get an
      *                 account name from the user. The resulting name must be between 1 and 30 ascii chars.
      */
@@ -238,8 +272,9 @@ export class BitBox02API {
         }
     }
 
-    /*
-     * btcDisplayAddressMultisig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcdisplayaddressmultisig
+    /**
+     * # Display a multisig address on the device. `btcMaybeRegisterScriptConfig` should be called beforehand.
+     *
      * @param account same as in `btcMaybeRegisterScriptConfig`.
      * @param keypath address-level keypath from the account, usually `account.keypathAccount.concat([0, address])`.
      */
@@ -252,8 +287,9 @@ export class BitBox02API {
         );
     }
 
-    /*
-     * btcSignMultisig: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#btcsignmultisig
+    /**
+     * # Sign a multisig transaction. `btcMaybeRegisterScriptConfig` should be called beforehand.
+     *
      * @param account same as in `btcMaybeRegisterScriptConfig`.
      * Other params and return are the same as in `btcSignSimple`.
      */
@@ -273,8 +309,14 @@ export class BitBox02API {
         );
     }
 
+
+    // --- End Bitcoin methods ---
+
+    // --- Ethereum methods ---
+
     /**
-     * ethGetRootPubKey: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethgetrootpubkey
+     * # Get Ethereum xPub key for a given coin and derivation path.
+     *
      * @param keypath account keypath in string format
      * @returns string; ethereum extended public key
      */
@@ -292,7 +334,8 @@ export class BitBox02API {
     };
 
     /**
-     * ethDisplayAddress: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethdisplayaddress
+     * # Display an Ethereum address on the device screen for verification.
+     *
      * @param keypath string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
      */
     async ethDisplayAddress(keypath) {
@@ -310,7 +353,10 @@ export class BitBox02API {
     };
 
     /**
-     * ethSignTransaction: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethsigntransaction
+     * # Signs an Ethereum transaction on the device.
+     *
+     * We recommend using the [`Transaction` type](https://github.com/ethereumjs/ethereumjs-tx/blob/master/src/transaction.ts) provided by the `ethereumjs` library.\
+     *
      * @param signingData Object
      * @returns Object; result with the signature bytes r, s, v
      */
@@ -343,7 +389,8 @@ export class BitBox02API {
     };
 
     /**
-     * ethSignMessage: see https://github.com/digitalbitbox/bitbox02-api-js/blob/master/docs/methods.md#ethsignmessage
+     * # Sign an Ethereum message on the device.
+     *
      * @param msgData is an object including the keypath and the message as bytes
      * @returns Object; result with the signature bytes r, s, v
      */
@@ -370,6 +417,8 @@ export class BitBox02API {
             }
         }
     }
+
+    // --- End Ethereum methods ---
 
     /**
      * @returns True if the connection has been opened and successfully established.

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export { getKeypathFromString } from './utils.js';
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,17 @@
+// Copyright 2019 Shift Cryptosecurity AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { constants, HARDENED } from './bitbox02.js';
 
 export const getCoinFromChainId = chainId => {


### PR DESCRIPTION
To simplifiy the README and avoid inconsistencies in the future, the methods documentation is moved to a seperate file. Existing documentation is removed from README and source code.

Minor wording adjustments for better readability.