### PR TITLE
update docs and add btcDisplayAddressSimple return address

### DIFF
--- a/demo/assets/styles/demo.css
+++ b/demo/assets/styles/demo.css
@@ -199,7 +199,7 @@ button {
     font-size: var(--buttonFontSize);
     font-weight: 300;
     text-align: center;
-    height: 52px;
+    min-height: 52px;
     line-height: 52px;
     min-width: var(--buttonWidth);
     cursor: pointer;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -140,13 +140,28 @@ ethSignMsg.addEventListener("click", async () => {
 });
 
 // Display single-sig BTC address on device for verification
-document.getElementById("btcAddressSimple").addEventListener("click", async () => {
+const simpleBtn = document.getElementById("btcAddressSimple");
+simpleBtn.addEventListener("click", async () => {
     const address = await device.api.btcDisplayAddressSimple(
         constants.messages.BTCCoin.BTC,
         getKeypathFromString("m/49'/0'/0'/0/0"),
         constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH,
+        false,
     );
-    alert("btcDisplayAddressSimple returned:\n" + address);
+    simpleBtn.textContent = "Confirm the following address on the BitBox:\n" + address;
+    simpleBtn.className = "btn btn-warning";
+    try {
+        const addressConfirmed = await device.api.btcDisplayAddressSimple(
+            constants.messages.BTCCoin.BTC,
+            getKeypathFromString("m/49'/0'/0'/0/0"),
+            constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH,
+        );
+        simpleBtn.textContent = "Success!:\n" + addressConfirmed;
+        simpleBtn.className = "btn btn-success";
+    } catch (e) {
+        simpleBtn.textContent = JSON.stringify(e);
+        simpleBtn.className = "btn btn-danger";
+    }
 });
 
 // Mock sample single-sig BTC transaction

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -98,8 +98,19 @@ ethPub.addEventListener("click", async () => {
 
 // Get ethereum address for given keypath
 // Only displays address on device, does not return. For verification, derive address from xpub
-ethAddr.addEventListener("click", async () => {
-    await device.api.ethDisplayAddress("m/44'/60'/0'/0/0");
+const ethAddrBtn = document.querySelector("#ethAddr");
+ethAddrBtn.addEventListener("click", async () => {
+    const address = await device.api.ethDisplayAddress("m/44'/60'/0'/0/0", false);
+    ethAddrBtn.textContent = "Confirm the following address on the BitBox:\n" + address;
+    ethAddrBtn.className = "btn btn-warning";
+    try {
+        const addressConfirmed = await device.api.ethDisplayAddress("m/44'/60'/0'/0/0");
+        ethAddrBtn.textContent = "Success!:\n" + addressConfirmed;
+        ethAddrBtn.className = "btn btn-success";
+    } catch (e) {
+        ethAddrBtn.textContent = JSON.stringify(e);
+        ethAddrBtn.className = "btn btn-danger";
+    }
 });
 
 // Sign ethereum transaction

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -141,11 +141,12 @@ ethSignMsg.addEventListener("click", async () => {
 
 // Display single-sig BTC address on device for verification
 document.getElementById("btcAddressSimple").addEventListener("click", async () => {
-    await device.api.btcDisplayAddressSimple(
+    const address = await device.api.btcDisplayAddressSimple(
         constants.messages.BTCCoin.BTC,
         getKeypathFromString("m/49'/0'/0'/0/0"),
         constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH,
     );
+    alert("btcDisplayAddressSimple returned:\n" + address);
 });
 
 // Mock sample single-sig BTC transaction

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -28,7 +28,7 @@ const xPub = await BitBox02.btcXPub(coin, keypath, xpubType, display);
 ### btcDisplayAddressSimple
 
 Display a Bitcoin single-sig address on the device.
-Return the address after users confirmation or throw "aborted by the user" error.
+Return a promise with the address after users confirmation or throw "aborted by the user" error.
 The address to be shown in the wallet is usually derived from the xpub (see `btcXPub`) and account type.
 
 ```javascript
@@ -37,7 +37,8 @@ The address to be shown in the wallet is usually derived from the xpub (see `btc
  * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
  *                Note: the keypaths are strictly enforced according to bip44, and must match the provided script/address types.
  * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
- * @return address string or aborted error
+ * @param display wheter to display the address on the device for user confirmation, default true.
+ * @return promise with address string or reject with aborted error
  */
 const address = await BitBox02.btcDisplayAddressSimple(coin, keypath, simpleType);
 ```

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -28,6 +28,7 @@ const xPub = await BitBox02.btcXPub(coin, keypath, xpubType, display);
 ### btcDisplayAddressSimple
 
 Display a Bitcoin single-sig address on the device.
+Return the address after users confirmation or throw "aborted by the user" error.
 The address to be shown in the wallet is usually derived from the xpub (see `btcXPub`) and account type.
 
 ```javascript
@@ -36,8 +37,9 @@ The address to be shown in the wallet is usually derived from the xpub (see `btc
  * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
  *                Note: the keypaths are strictly enforced according to bip44, and must match the provided script/address types.
  * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
+ * @return address string or aborted error
  */
-await BitBox02.btcDisplayAddressSimple(coin, keypath, simpleType);
+const address = await BitBox02.btcDisplayAddressSimple(coin, keypath, simpleType);
 ```
 
 ### btcSignSimple

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -385,20 +385,22 @@ export class BitBox02API {
     };
 
     /**
-     * # Display an Ethereum address on the device screen for verification.
+     * Display an Ethereum address on the device screen for verification.
      *
      * @param keypath string, e.g. m/44'/60'/0'/0/0 for the first mainnet account
+     * @param display wheter to display the address on the device for user confirmation, default true.
+     * @returns promise with the ETH address or reject with aborted error
      */
-    async ethDisplayAddress(keypath) {
+    async ethDisplayAddress(keypath, display = true) {
         const keypathArray = getKeypathFromString(keypath);
         // FIXME: see def of `getCoinFromPath()`, since we use the same keypath for Ropsten and Rinkeby,
         // the title for Rinkeby addresses will show 'Ropsten' instead
         const coin = getCoinFromKeypath(keypathArray);
-        this.firmware().js.AsyncETHPub(
+        return this.firmware().js.AsyncETHPub(
             coin,
             keypathArray,
             constants.messages.ETHPubRequest_OutputType.ADDRESS,
-            true,
+            display,
             new Uint8Array()
         );
     };

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -199,15 +199,16 @@ export class BitBox02API {
     }
 
     /**
-     * # Display a single-sig address on the device. The address to be shown in the wallet is usually derived
-     * # from the xpub (see `btcXPub` and account type.
+     * Display a single-sig address on the device. The address to be shown in the wallet is usually derived
+     * from the xpub (see `btcXPub` and account type.
      *
      * @param coin Coin to target - `constants.messages.BTCCoin.*`, for example `constants.messages.BTCCoin.BTC`.
      * @param keypath address-level keypath, for example `getKeypathFromString("m/49'/0'/0'/1/10")`.
      * @param simpleType is the address type - `constants.messages.BTCScriptConfig_SimpleType.*`, for example `constants.messages.BTCScriptConfig_SimpleType.P2WPKH_P2SH` for `3...` segwit addresses.
+     * @param display wheter to display the address on the device for user confirmation, default true.
+     * @return promise with address string or reject with aborted error
      */
-    async btcDisplayAddressSimple(coin, keypath, simpleType) {
-        const display = true;
+    async btcDisplayAddressSimple(coin, keypath, simpleType, display = true) {
         return this.firmware().js.AsyncBTCAddressSimple(
             coin,
             keypath,


### PR DESCRIPTION
- added support for display=false for `btcDisplayAddressSimple` and `ethDisplayAddress`
- update documentation on methods.md
- changed demo.js to first get an address with display=false, show the address and then ask to confirm the address on the bitbox