### PR TITLE
Remove additional offset of 27

### DIFF
--- a/lib/bitbox02.js
+++ b/lib/bitbox02.js
@@ -919,7 +919,7 @@ var BitBox02API = /*#__PURE__*/function () {
                 result = {
                   r: sig.slice(0, 0 + 32),
                   s: sig.slice(0 + 32, 0 + 32 + 32),
-                  v: [parseInt(sig.slice(64), 16) + 27 + vOffset]
+                  v: [sig[64] + 27 + vOffset]
                 };
                 return _context12.abrupt("return", result);
 
@@ -986,7 +986,8 @@ var BitBox02API = /*#__PURE__*/function () {
                 result = {
                   r: sig.slice(0, 0 + 32),
                   s: sig.slice(0 + 32, 0 + 32 + 32),
-                  v: [parseInt(sig.slice(64), 16) + 27]
+                  v: sig.slice(64) // offset of 27 is already included by bitbox02-api-go
+
                 };
                 return _context13.abrupt("return", result);
 

--- a/src/bitbox02.js
+++ b/src/bitbox02.js
@@ -524,7 +524,7 @@ export class BitBox02API {
             const result = {
                 r: sig.slice(0, 0 + 32),
                 s: sig.slice(0 + 32, 0 + 32 + 32),
-                v: [parseInt(sig.slice(64), 16) + 27 + vOffset]
+                v: [sig[64] + 27 + vOffset],
             };
             return result;
         } catch (err) {
@@ -563,7 +563,7 @@ export class BitBox02API {
             const result = {
                 r: sig.slice(0, 0 + 32),
                 s: sig.slice(0 + 32, 0 + 32 + 32),
-                v: [parseInt(sig.slice(64), 16) + 27]
+                v: sig.slice(64), // offset of 27 is already included by bitbox02-api-go
             };
             return result;
         } catch (err) {


### PR DESCRIPTION
Since
https://github.com/digitalbitbox/bitbox02-api-go/commit/971fa13fa6d4f3cf78df85ddfe6fcad8a4b541c2,
the offset of 27 is added already in the Go library.

The update was pulled in in c4379142f5c596327eab20e9bc9f3b53e6c70b46.

Adding the offset again is incorrect.