### PR TITLE
lower version number that was erroneously bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbox02-api",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "description": "BitBox02 JavaScript library – To enable communication from the browser to the BitBox02 hardware wallet",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
The last tagged and released version is 0.8.1. We accidentally bumped
the major version twice. The next version is going to be 0.9.0.