### PR TITLE
gopherjs: allow using gopherjs outside of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ FROM golang:1.16-buster
 RUN curl -o /gopherjs.tar.gz -sSL https://github.com/gopherjs/gopherjs/archive/refs/tags/1.16.4+go1.16.7.tar.gz
 RUN mkdir /gopherjs && tar -xf /gopherjs.tar.gz --strip-components=1 -C /gopherjs
 RUN cd /gopherjs && go build
-
+ENV PATH="/gopherjs/:${PATH}"
 CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ dockercompile:
 servedemo:
 	cd demo && python3 -m http.server 8000
 compile:
-	cd gowrapper && /gopherjs/gopherjs build -m -o /bitbox02-api-js/src/bitbox02-api-go.js
+	cd gowrapper && gopherjs build -o ../src/bitbox02-api-go.js
 dockerinit:
 	docker build --no-cache --pull --force-rm -t bitbox02-api-js .


### PR DESCRIPTION
Current compile step only works in docker as the path expect to be
inside docker container. Allow usign make copile without docker.